### PR TITLE
Upgrade to C++23, get rid of some dependencies, fix segfault

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -39,7 +39,6 @@ IndentWidth: 4
 UseTab: Never
 ColumnLimit: 100
 IndentPPDirectives: AfterHash
-BreakConstructorInitializers: AfterColon
 ConstructorInitializerIndentWidth: 4
 IncludeBlocks: Regroup
 BraceWrapping:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .vscode
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,22 +11,18 @@ message("-- Found Python ${Python3_EXECUTABLE}")
 
 include(cmake/unicode_data.cmake)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(namesgen tools/names.cpp)
 
 find_package(Threads REQUIRED)
-find_package(TBB CONFIG REQUIRED)
-find_package(range-v3 CONFIG REQUIRED)
-find_package(fmt CONFIG REQUIRED)
 find_package(pugixml CONFIG REQUIRED)
 
 target_link_libraries(namesgen PRIVATE
   Threads::Threads
   pugixml
-  fmt::fmt
-  TBB::tbb
-  range-v3-concepts
 )
 
 SET(HEADERS_DIR ${PROJECT_BINARY_DIR}/include/cedilla/)
@@ -37,9 +33,6 @@ add_executable(namesreversegen
 
 target_link_libraries(namesreversegen PRIVATE
   pugixml
-  fmt::fmt
-  TBB::tbb
-  range-v3-concepts
   Threads::Threads
 )
 target_compile_options(namesreversegen PRIVATE "-fopenmp-simd" "-march=native")

--- a/src/cedilla/base.h
+++ b/src/cedilla/base.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <algorithm>
 #include <string_view>
+#include <cstdint>
 
 namespace uni::detail {
 
@@ -72,7 +73,7 @@ struct compact_range {
     std::uint32_t _data[N];
     constexpr T value(char32_t cp, T default_value) const {
         const auto end = std::end(_data);
-        auto it = detail::upper_bound(std::begin(_data), end, cp, [](char32_t local_cp, uint32_t v) {
+        auto it = detail::upper_bound(std::begin(_data), end, cp, [](char32_t local_cp, std::uint32_t v) {
             char32_t c = (v >> 8);
             return local_cp < c;
         });
@@ -91,7 +92,7 @@ struct compact_list {
     std::uint32_t _data[N];
     constexpr T value(char32_t cp, T default_value) const {
         const auto end = std::end(_data);
-        auto it = detail::lower_bound(std::begin(_data), end, cp, [](uint32_t v, char32_t local_cp) {
+        auto it = detail::lower_bound(std::begin(_data), end, cp, [](std::uint32_t v, char32_t local_cp) {
             char32_t c = (v >> 8);
             return c < local_cp;
         });
@@ -119,9 +120,9 @@ using array_t = typename array<T, N>::type;
 
 
 
-template<std::size_t r1_s, std::size_t r2_s, int16_t r2_t_f, int16_t r2_t_b, std::size_t r3_s,
-         std::size_t r4_s, int16_t r4_t_f, int16_t r4_t_b, std::size_t r5_s, int16_t r5_t_f,
-         int16_t r5_t_b, std::size_t r6_s>
+template<std::size_t r1_s, std::size_t r2_s, std::int16_t r2_t_f, std::int16_t r2_t_b, std::size_t r3_s,
+         std::size_t r4_s, std::int16_t r4_t_f, std::int16_t r4_t_b, std::size_t r5_s, std::int16_t r5_t_f,
+         std::int16_t r5_t_b, std::size_t r6_s>
 struct bool_trie {
 
     // not tries, just bitmaps for all code points 0..0x7FF (UTF-8 1- and 2-byte sequences)
@@ -206,7 +207,7 @@ struct range_array {
     std::uint32_t _data[N];
     constexpr bool lookup(char32_t cp) const {
         const auto end = std::end(_data);
-        auto it = detail::upper_bound(std::begin(_data), end, cp, [](char32_t local_cp, uint32_t v) {
+        auto it = detail::upper_bound(std::begin(_data), end, cp, [](char32_t local_cp, std::uint32_t v) {
             char32_t c = (v >> 8);
             return local_cp < c;
         });
@@ -269,7 +270,7 @@ struct pair
 template <typename A, typename B>
 pair(A, B) -> pair<A, B>;
 
-struct string_with_idx { const char* name; uint32_t value; };
+struct string_with_idx { const char* name; std::uint32_t value; };
 
 
 }    // namespace uni::detail
@@ -292,7 +293,7 @@ constexpr bool numeric_value::is_valid() const {
     return _d != 0;
 }
 
-constexpr numeric_value::numeric_value(long long n, int16_t d) : _n(n), _d(d) {}
+constexpr numeric_value::numeric_value(long long n, std::int16_t d) : _n(n), _d(d) {}
 
 
 }    // namespace uni

--- a/src/cedilla/synopsys.h
+++ b/src/cedilla/synopsys.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string_view>
+#include <cstdint>
 
 #ifndef CTRE_UNICODE_SYNOPSYS_WAS_INCLUDED
 namespace uni
@@ -48,10 +49,10 @@ namespace uni
 
     protected:
         constexpr numeric_value() = default;
-        constexpr numeric_value(long long n, int16_t d);
+        constexpr numeric_value(long long n, std::int16_t d);
 
         long long _n = 0;
-        int16_t _d = 0;
+        std::int16_t _d = 0;
         friend constexpr numeric_value cp_numeric_value(char32_t cp);
     };
 

--- a/src/cedilla/unicode.h
+++ b/src/cedilla/unicode.h
@@ -127,7 +127,7 @@ constexpr version cp_age(char32_t cp) {
 
 constexpr block cp_block(char32_t cp) {
     const auto end = std::end(detail::tables::block_data._data);
-    auto it = detail::upper_bound(std::begin(detail::tables::block_data._data), end, cp, [](char32_t cp_, uint32_t v) {
+    auto it = detail::upper_bound(std::begin(detail::tables::block_data._data), end, cp, [](char32_t cp_, std::uint32_t v) {
         char32_t c = (v >> 8);
         return cp_ < c;
     });
@@ -263,7 +263,7 @@ constexpr numeric_value cp_numeric_value(char32_t cp) {
        }())) {
         return {};
     }
-    int16_t d = 1;
+    std::int16_t d = 1;
     detail::get_numeric_value(cp, detail::tables::numeric_data_d, d);
     return numeric_value(res, d);
 }

--- a/src/name_to_cp.hpp
+++ b/src/name_to_cp.hpp
@@ -1,13 +1,15 @@
 #include <string_view>
 #include <tuple>
 #include <charconv>
+#include <cstdint>
+
 namespace uni {
     namespace details {
         struct node {
             char32_t value  = 0xFFFFFF;
-            uint32_t children_offset = 0;
+            std::uint32_t children_offset = 0;
             bool has_sibling = false;
-            uint32_t size = 0;
+            std::uint32_t size = 0;
             std::string_view name;
 
 
@@ -18,20 +20,20 @@ namespace uni {
                 return children_offset != 0;
             }
         };
-        constexpr node read_node(uint32_t offset) {
+        constexpr node read_node(std::uint32_t offset) {
             using namespace uni::details;
             const uint32_t origin = offset;
             node n;
 
-            uint8_t name = index[offset++];
+            std::uint8_t name = index[offset++];
             if(offset + 6 >= sizeof(index))
                 return n;
 
             const bool long_name = name & 0x40;
             const bool has_value = name & 0x80;
-            name &= ~0xC0;
+            name = std::uint8_t(name & ~0xC0);
             if(long_name) {
-                uint32_t name_offset = (index[offset++] << 8u);
+                std::uint32_t name_offset = (index[offset++] << 8u);
                 name_offset |= index[offset++];
                 n.name = std::string_view(dict + name_offset, name);
             }
@@ -39,28 +41,28 @@ namespace uni {
                n.name = std::string_view(dict + name, 1);
             }
             if(has_value) {
-                uint8_t h = index[offset++];
-                uint8_t m = index[offset++];
-                uint8_t l = index[offset++];
+                std::uint8_t h = index[offset++];
+                std::uint8_t m = index[offset++];
+                std::uint8_t l = index[offset++];
                 n.value = uint32_t((h << 16u) | (m << 8u) | l) >> 3u;
 
                 bool has_children = l & 0x02;
                 n.has_sibling = l & 0x01;
 
                 if(has_children) {
-                    n.children_offset  = uint32_t(index[offset++] << 16u);
-                    n.children_offset |= uint32_t(index[offset++] << 8u);
+                    n.children_offset  = std::uint32_t(index[offset++] << 16u);
+                    n.children_offset |= std::uint32_t(index[offset++] << 8u);
                     n.children_offset |= index[offset++];
                 }
             }
             else {
-                uint8_t h = index[offset++];
+                std::uint8_t h = index[offset++];
                 n.has_sibling = h & 0x80;
                 bool has_children = h & 0x40;
-                h &= ~0xC0;
+                h = std::uint8_t(name & ~0xC0);
                 if(has_children) {
                     n.children_offset = (h << 16u);
-                    n.children_offset |= (uint32_t(index[offset++]) << 8u);
+                    n.children_offset |= (std::uint32_t(index[offset++]) << 8u);
                     n.children_offset |= index[offset++];
                 }
             }
@@ -69,7 +71,7 @@ namespace uni {
         }
 
 
-        constexpr int compare(std::string_view str, std::string_view needle, uint32_t start) {
+        constexpr int compare(std::string_view str, std::string_view needle, std::uint32_t start) {
             std::size_t str_i = start;
             std::size_t needle_i = 0;
             if(needle.size() == 0)
@@ -101,14 +103,14 @@ namespace uni {
             return -1;
         }
 
-        constexpr std::tuple<node, bool, uint32_t>
-        compare_node(uint32_t offset, std::string_view name, uint32_t start = 0) {
+        constexpr std::tuple<node, bool, std::uint32_t>
+        compare_node(std::uint32_t offset, std::string_view name, std::uint32_t start = 0) {
             auto n = details::read_node(offset);
             auto cmp = details::compare(name, n.name, start);
             if(cmp == -1) {
                 return {n, false, 0};
             }
-            start = uint32_t(cmp);
+            start = std::uint32_t(cmp);
             if(name.size() == start)
                 return {n, true, n.value};
             if(n.has_children()) {
@@ -159,8 +161,8 @@ namespace uni {
 
         struct generated_name_data {
             std::string_view prefix;
-            uint32_t start;
-            uint32_t end;
+            std::uint32_t start;
+            std::uint32_t end;
         };
 
         constexpr const generated_name_data generated_name_data_table[] = {
@@ -183,7 +185,7 @@ namespace uni {
             return str.size() >= needle.size() && str.compare(0, needle.size(), needle) == 0;
         }
 
-        constexpr uint32_t find_syllable(std::string_view str, int & pos, int count, int column) {
+        constexpr std::uint32_t find_syllable(std::string_view str, int & pos, int count, int column) {
             int len = -1;
             for (int i = 0; i < count; i++) {
                 std::string_view s(hangul_syllables[i][column]);
@@ -196,18 +198,18 @@ namespace uni {
             }
             if (len == -1)
                 len = 0;
-            return uint32_t(len);
+            return std::uint32_t(len);
         }
 
         constexpr const char32_t SBase = 0xAC00;
         constexpr const char32_t LBase = 0x1100;
         constexpr const char32_t VBase = 0x1161;
         constexpr const char32_t TBase = 0x11A7;
-        constexpr const uint32_t LCount = 19;
-        constexpr const uint32_t VCount = 21;
-        constexpr const uint32_t TCount = 28;
-        constexpr const uint32_t NCount = (VCount * TCount);
-        constexpr const uint32_t SCount = (LCount * NCount);
+        constexpr const std::uint32_t LCount = 19;
+        constexpr const std::uint32_t VCount = 21;
+        constexpr const std::uint32_t TCount = 28;
+        constexpr const std::uint32_t NCount = (VCount * TCount);
+        constexpr const std::uint32_t SCount = (LCount * NCount);
     }
 
 
@@ -230,7 +232,7 @@ namespace uni {
             if (starts_with(name, item.prefix)) {
                 auto gn = name;
                 gn.remove_prefix(item.prefix.size());
-                uint32_t v = 0;
+                std::uint32_t v = 0;
                 const auto end = gn.data() + gn.size();
                 auto [p, ec] = std::from_chars(gn.data(), end , v, 16);
                 if(ec != std::errc() || p != end || v < item.start || v > item.end)
@@ -239,7 +241,7 @@ namespace uni {
             }
         }
 
-        uint32_t offset = 0;
+        std::uint32_t offset = 0;
         for(;;) {
             auto [n, res, value] = details::compare_node(offset, name);
             if(!n.is_valid())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,4 +12,4 @@ endmacro()
 create_test(tst_prop_script prop_script.cpp)
 
 create_test(tst_name tst_names.cpp)
-target_link_libraries(tst_name fmt::fmt)
+target_link_libraries(tst_name)

--- a/tests/tst_names.cpp
+++ b/tests/tst_names.cpp
@@ -2,7 +2,6 @@
 #include <cedilla/name_to_cp.hpp>
 #include <cedilla/cp_to_name.hpp>
 #include <iostream>
-#include <fmt/format.h>
 #include <set>
 #include "common.h"
 #include <catch2/catch.hpp>
@@ -36,8 +35,11 @@ TEST_CASE("Verify that all code point have the same name as in the DB") {
                 continue;
             const auto & name = it->second.name;
             const auto res = uni::cp_name(c).to_string();
-            fmt::print("{:0x} :  expected {} found {}\n", uint32_t(c)
-            , name, res );
+            // We do not use std::print here because these tests are compiled in C++17
+            // to verify compatibility, unlike the rest of the project.
+            std::cout << std::hex << std::uint32_t(c)
+                      << " : expected " << name
+                      << " found " << res << '\n';
             CHECK(res == name);
         }
     }

--- a/tools/names.cpp
+++ b/tools/names.cpp
@@ -1,34 +1,16 @@
 #include "pugixml.hpp"
+#include <algorithm>
+#include <ranges>
 #include <unordered_map>
 #include <unordered_set>
 #include <string>
-#include <iostream>
-#include <charconv>
 #include <utility>
 #include <vector>
 #include <string>
-#include <execution>
-#include <fmt/ranges.h>
-#include <fmt/ostream.h>
-#include <fmt/format.h>
-#include <range/v3/view/transform.hpp>
-#include <range/v3/view/span.hpp>
-#include <range/v3/view/iota.hpp>
-#include <range/v3/view/chunk.hpp>
-#include <range/v3/view/counted.hpp>
-#include <range/v3/range/conversion.hpp>
-#include <range/v3/algorithm/any_of.hpp>
-#include <range/v3/algorithm/sort.hpp>
-#include <range/v3/view/remove_if.hpp>
-#include <range/v3/algorithm/equal.hpp>
-#include <range/v3/view/take.hpp>
-#include <range/v3/view/unique.hpp>
-#include <range/v3/view/enumerate.hpp>
-#include <range/v3/numeric/accumulate.hpp>
-#include <range/v3/algorithm/copy.hpp>
-#include "range/v3/view/span.hpp"
-
 #include <mutex>
+#include <print>
+
+namespace ranges = std::ranges;
 
 bool generated(char32_t c) {
     const std::array ranges = {
@@ -121,7 +103,7 @@ template<typename R>
 auto substrings(R&& r) {
     std::mutex m;
     std::unordered_set<std::string_view, std::hash<std::string_view>> set;
-    std::for_each(std::execution::par_unseq, ranges::begin(r), ranges::end(r),
+    std::for_each(ranges::begin(r), ranges::end(r),
                       [&](const character_name& c) {
         for(const auto& b : c.bits()) {
             for(auto i : ranges::views::iota(std::size_t(1), b.second.size() + 1)) {
@@ -148,7 +130,7 @@ void inc(Map& map, K&& k) {
 
 template<typename Map>
 auto sorted_by_occurences(Map& map) {
-    auto v = map | ranges::to<std::vector<std::pair<typename Map::key_type, int>>>;
+    auto v = map | ranges::to<std::vector<std::pair<typename Map::key_type, int>>>();
     ranges::sort(v, std::greater<>{}, &std::pair<typename Map::key_type, int>::second);
     return v;
 }
@@ -172,26 +154,26 @@ void print_dict(std::FILE* f, const std::vector<block> & blocks) {
 
     int idx = 1;
     std::unordered_map<int, data> table;
-    fmt::print(f, "constexpr const char* __name_dict = \"");
+    std::print(f, "constexpr const char* __name_dict = \"");
     for(const auto& b: blocks) {
         for(const auto& str : b.data) {
             for(auto c : str) {
-                fmt::print(f, "{}", c);
+                std::print(f, "{}", c);
             }
         }
         table[idx++] = data{start, b.elem_size, b.data.size()};
         start += b.elem_size * b.data.size();
     }
-    fmt::print(f, "\";");
-    fmt::print(f,
+    std::print(f, "\";");
+    std::print(f,
                "constexpr std::string_view __get_name_segment(std::size_t b, std::size_t idx) {{");
-    fmt::print(f, "switch(b) {{");
+    std::print(f, "switch(b) {{");
     for(const auto& [k, v] : table) {
-        fmt::print(f, "case {}:", k);
-        fmt::print(f, "return std::string_view{{__name_dict + {0} + idx * {1}, {1} }};", v.start,
+        std::print(f, "case {}:", k);
+        std::print(f, "return std::string_view{{__name_dict + {0} + idx * {1}, {1} }};", v.start,
                    v.elem_size);
     }
-    fmt::print(f, "}} return {{}};}}");
+    std::print(f, "}} return {{}};}}");
 }
 void print_indexes(std::FILE* f,
                    const std::unordered_map<int, std::unordered_map<char32_t, uint64_t>>& mapping) {
@@ -202,12 +184,12 @@ void print_indexes(std::FILE* f,
     std::vector<uint64_t> data;
 
     auto sorted_mapping =
-        mapping | ranges::to<std::vector<std::pair<int, std::unordered_map<char32_t, uint64_t>>>>;
+        mapping | ranges::to<std::vector<std::pair<int, std::unordered_map<char32_t, uint64_t>>>>();
     ranges::sort(sorted_mapping, {},
                  &std::pair<int, std::unordered_map<char32_t, uint64_t>>::first);
 
     for(auto& [k, v] : sorted_mapping) {
-        auto arr = v | ranges::to<std::vector<std::pair<char32_t, uint64_t>>>;
+        auto arr = v | ranges::to<std::vector<std::pair<char32_t, uint64_t>>>();
         ranges::sort(arr, {}, &std::pair<char32_t, uint64_t>::first);
         for(auto& d : arr) {
             data.push_back(d.second);
@@ -216,40 +198,40 @@ void print_indexes(std::FILE* f,
         start = data.size();
     }
 
-    fmt::print(f, "constexpr uint64_t __name_indexes[] = {{");
+    std::print(f, "constexpr uint64_t __name_indexes[] = {{");
     for(auto& elem : data) {
-        fmt::print(f, "{:#018x},", elem);
+        std::print(f, "{:#018x},", elem);
     }
-    fmt::print(f, "0xFFFF'FFFF'FFFF'FFFF}};");
+    std::print(f, "0xFFFF'FFFF'FFFF'FFFF}};");
 
     for(const auto& [index, data] : ranges::views::enumerate(sorted_jump_table)) {
-        fmt::print(f, "constexpr uint64_t __name_indexes_{}[] = {{", index);
+        std::print(f, "constexpr uint64_t __name_indexes_{}[] = {{", index);
         bool first = true;
         char32_t prev = 0;
         size_t next_start = data.first;
         for(auto& c : data.second) {
             if(first || c.first != prev + 1) {
-                fmt::print(f, "{:#018x},", (uint64_t(prev + 1) << 32) | uint32_t(0xFFFFFFFF));
-                fmt::print(f, "{:#018x},", (uint64_t(c.first) << 32) | uint32_t(next_start));
+                std::print(f, "{:#018x},", (uint64_t(prev + 1) << 32) | uint32_t(0xFFFFFFFF));
+                std::print(f, "{:#018x},", (uint64_t(c.first) << 32) | uint32_t(next_start));
             }
             first = false;
             prev = c.first;
             next_start++;
         }
-        fmt::print(f, "{:#018x}}};", (uint64_t(prev + 1) << 32) | uint32_t(0xFFFFFFFF));
+        std::print(f, "{:#018x}}};", (uint64_t(prev + 1) << 32) | uint32_t(0xFFFFFFFF));
     }
 
-    fmt::print(f, "constexpr std::pair<const uint64_t* const, const uint64_t* const> "
+    std::print(f, "constexpr std::pair<const uint64_t* const, const uint64_t* const> "
                   "__get_table_index(std::size_t index) {{");
-    fmt::print(f, "switch(index) {{");
+    std::print(f, "switch(index) {{");
     for(const auto& [index, data] : ranges::views::enumerate(sorted_jump_table)) {
-        fmt::print(f, "case {}:", index);
-        fmt::print(f,
+        std::print(f, "case {}:", index);
+        std::print(f,
                    "return {{  __name_indexes_{0},  __name_indexes_{0} +  "
                    "sizeof(__name_indexes_{0})/sizeof(uint64_t) }};",
                    index);
     }
-    fmt::print(f, "}} return {{nullptr, nullptr}}; }}");
+    std::print(f, "}} return {{nullptr, nullptr}}; }}");
 }
 
 int main(int argc, char** argv) {
@@ -258,7 +240,7 @@ int main(int argc, char** argv) {
     auto names = data | ranges::views::transform([](const auto& p) {
                      return character_name{p.first, p.second, {}, 0};
                  }) |
-                 ranges::to<std::vector>;
+                 ranges::to<std::vector>();
 
     std::mutex m;
     std::unordered_map<std::string_view, int> all_used;
@@ -267,21 +249,21 @@ int main(int argc, char** argv) {
     auto end = names.end();
 
     while(true) {
-        end = std::partition(std::execution::par_unseq, names.begin(), end,
+        end = std::partition(names.begin(), end,
             [](const auto & a) {
                 return !a.complete();
             });
         auto incomplete = ranges::views::counted(names.begin(), std::size_t(ranges::distance(names.begin(), end)));
 
-        fmt::print("Count : {}\n", ranges::distance(incomplete));
+        std::print("Count : {}\n", ranges::distance(incomplete));
 
         if(ranges::empty(incomplete)) {
             break;
         }
 
         const auto subs = [&incomplete] {
-            auto tmp = substrings(incomplete) | ranges::to<std::vector>;
-            std::sort(std::execution::par_unseq, tmp.begin(), tmp.end(),
+            auto tmp = substrings(incomplete) | ranges::to<std::vector>();
+            std::sort(tmp.begin(), tmp.end(),
             [](const auto & a, const auto & b) {
                 return a.size() > b.size();
             });
@@ -297,10 +279,10 @@ int main(int argc, char** argv) {
         // Compute a list of all possible substrings for each char
         // the value is the distance
 
-        std::for_each(std::execution::par_unseq, incomplete.begin(), incomplete.end(),
+        std::for_each(incomplete.begin(), incomplete.end(),
                       [&used_substrings](const character_name& c) {
                 const auto bits = c.bits();
-                std::for_each(std::execution::par_unseq,
+                std::for_each(
                 ranges::begin(bits),
                 ranges::end(bits), [&used_substrings, &c](const auto & b) {
                         for(auto i : ranges::views::iota(std::size_t(0), b.second.size() + 1)) {
@@ -316,20 +298,20 @@ int main(int argc, char** argv) {
                     });
                 });
 
-        fmt::print("Substrings : {}\n", subs.size());
+        std::print("Substrings : {}\n", subs.size());
 
         std::vector<std::pair<std::string_view, double>> weighted_substrings =
-            used_substrings | ranges::views::remove_if([](const auto& p) {
-                return p.second == 0;
+            used_substrings | ranges::views::filter([](const auto& p) {
+                return p.second != 0;
             }) |
             ranges::views::transform([](const auto& p) {
                 const double d =
                     p.first.size() < 5 ? 1.0 : double(p.second) * p.first.size();
                 return std::pair<std::string_view, double>{p.first, d};
-            }) | ranges::to<std::vector>;
-        fmt::print("Used Substrings : {}\n", weighted_substrings.size());
+            }) | ranges::to<std::vector>();
+        std::print("Used Substrings : {}\n", weighted_substrings.size());
         const auto count = std::size_t(1 + 0.01 * double(weighted_substrings.size()));
-        fmt::print("{}", count);
+        std::print("{}", count);
         std::partial_sort(
             std::begin(weighted_substrings),
             std::begin(weighted_substrings) + count + 1,
@@ -339,7 +321,7 @@ int main(int argc, char** argv) {
         );
         auto filtered =
             weighted_substrings | ranges::views::take(count) |
-            ranges::views::transform([](const auto& p) { return p.first; }) | ranges::to<std::vector<std::string_view>>;
+            ranges::views::transform([](const auto& p) { return p.first; }) | ranges::to<std::vector<std::string_view>>();
 
         std::partial_sort(
             std::begin(filtered),
@@ -351,7 +333,7 @@ int main(int argc, char** argv) {
 
         std::mutex mutex;
         for(const auto& s : filtered | ranges::views::take(10)) {
-            std::for_each(std::execution::par_unseq,
+            std::for_each(
                          ranges::begin(incomplete),
                          ranges::end(incomplete),
             [&] (auto & c){
@@ -366,7 +348,7 @@ int main(int argc, char** argv) {
                 }
             });
         }
-        fmt::print("------\n");
+        std::print("------\n");
     }
     auto strings = sorted_by_occurences(all_used);
 
@@ -395,11 +377,11 @@ int main(int argc, char** argv) {
 
     std::size_t dict_size = 0;
     for(const auto& b : blocks_by_size) {
-        fmt::print("--- BLOCK : string size : {}, elements  {} -- total {} ({})\n",
+        std::print("--- BLOCK : string size : {}, elements  {} -- total {} ({})\n",
                    b.elem_size, b.size(), b.elem_size * b.data.size(),
         dict_size += (b.elem_size * b.data.size()) );
     }
-    fmt::print("Total blocks: {}\n", blocks_by_size.size());
+    std::print("Total blocks: {}\n", blocks_by_size.size());
 
     std::size_t index_bytes = 0;
     std::unordered_map<int, int> lengths;
@@ -409,13 +391,18 @@ int main(int argc, char** argv) {
     }
 
     auto sorted_lengths = sorted_by_occurences(lengths);
-    // fmt::print("DICT : \n{}\n ----", strings);
-    fmt::print("LENGTHS : \n{}\n ----", sorted_lengths);
-    fmt::print("KBytes: {}  ( dict {}  + index : {} )\n", (index_bytes + dict_size) / 1024.0,
+    // std::print("DICT : \n{}\n ----", strings);
+    std::print("LENGTHS : \n");
+    for (const auto& [key, occurrences] : sorted_lengths) {
+        std::print("({}, {})", key, occurrences);
+    }
+    std::print("\n ----");
+
+    std::print("KBytes: {}  ( dict {}  + index : {} )\n", (index_bytes + dict_size) / 1024.0,
                dict_size / 1024.0, index_bytes / 1024.0);
 
     auto f = fopen(argv[2], "w");
-    fmt::print(f, "#pragma once\n#include <string_view>\n#include <array>\n\n");
+    std::print(f, "#pragma once\n#include <string_view>\n#include <array>\n\n");
 
     print_dict(f, blocks_by_size);
 

--- a/tools/names.cpp
+++ b/tools/names.cpp
@@ -330,7 +330,7 @@ int main(int argc, char** argv) {
         fmt::print("Used Substrings : {}\n", weighted_substrings.size());
         const auto count = std::size_t(1 + 0.01 * double(weighted_substrings.size()));
         fmt::print("{}", count);
-        std::partial_sort(std::execution::par_unseq,
+        std::partial_sort(
             std::begin(weighted_substrings),
             std::begin(weighted_substrings) + count + 1,
             std::end(weighted_substrings), [](const auto & a, const auto &b ) {
@@ -341,7 +341,7 @@ int main(int argc, char** argv) {
             weighted_substrings | ranges::views::take(count) |
             ranges::views::transform([](const auto& p) { return p.first; }) | ranges::to<std::vector<std::string_view>>;
 
-        std::partial_sort(std::execution::par_unseq,
+        std::partial_sort(
             std::begin(filtered),
             std::begin(filtered) + 11,
             std::end(filtered), [](const auto & a, const auto &b ) {

--- a/tools/names.cpp
+++ b/tools/names.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <mutex>
 #include <print>
+#include <cassert>
 
 namespace ranges = std::ranges;
 
@@ -323,9 +324,10 @@ int main(int argc, char** argv) {
             weighted_substrings | ranges::views::take(count) |
             ranges::views::transform([](const auto& p) { return p.first; }) | ranges::to<std::vector<std::string_view>>();
 
+        auto filtered_middle = std::min(std::ptrdiff_t(11), std::ptrdiff_t(filtered.size()));
         std::partial_sort(
             std::begin(filtered),
-            std::begin(filtered) + 11,
+            std::begin(filtered) + filtered_middle,
             std::end(filtered), [](const auto & a, const auto &b ) {
                 return a.size() > b.size();
             }

--- a/tools/namesreverse.cpp
+++ b/tools/namesreverse.cpp
@@ -1,32 +1,18 @@
 #include "pugixml.hpp"
+#include <algorithm>
+#include <ranges>
 #include <unordered_map>
-#include <map>
-#include <unordered_set>
 #include <string>
-#include <iostream>
 #include <deque>
-#include <charconv>
 #include <utility>
 #include <vector>
 #include <string>
 #include <set>
-#include <fmt/ranges.h>
-#include <fmt/ostream.h>
-#include <fmt/format.h>
 #include <optional>
-#include <range/v3/view/transform.hpp>
-#include <range/v3/view/iota.hpp>
-#include <range/v3/view/enumerate.hpp>
-#include <range/v3/range/conversion.hpp>
-#include <range/v3/algorithm/any_of.hpp>
-#include <range/v3/algorithm/sort.hpp>
-#include <range/v3/algorithm/find.hpp>
-#include <range/v3/algorithm/find_if.hpp>
-#include <range/v3/algorithm/remove_if.hpp>
-#include <locale>
-#include "range/v3/view/span.hpp"
+#include <memory>
+#include <print>
 
-#include <mutex>
+namespace ranges = std::ranges;
 
 bool generated(char32_t c) {
     const std::array ranges = {
@@ -141,7 +127,7 @@ public:
         bytes.reserve(250'000);
 
         auto add_children = [&sibling_nodes, &nodes](auto && container) {
-            for(auto && [idx, c] : ranges::view::enumerate(container)) {
+            for(auto && [idx, c] : ranges::views::enumerate(container)) {
                 nodes.push_back(c.get());
                 if(idx != container.size() - 1)
                     sibling_nodes[c.get()] = true;
@@ -294,16 +280,16 @@ int main(int argc, char** argv) {
     }
     t.compact();
     auto [dict, bytes] = t.dump();
-    fmt::print("//dict : {} / tree : {} \n", dict.size()/1024, bytes.size()/1024);
+    std::print("//dict : {} / tree : {} \n", dict.size()/1024, bytes.size()/1024);
 
 
-    fmt::print("#pragma once\n");
-    fmt::print("#include <cstdint>\n");
-    fmt::print("namespace uni::details {{\n");
-    fmt::print("constexpr const char* dict = \"{}\";\n", dict);
-    fmt::print("constexpr const uint8_t index[] = {{\n");
+    std::print("#pragma once\n");
+    std::print("#include <cstdint>\n");
+    std::print("namespace uni::details {{\n");
+    std::print("constexpr const char* dict = \"{}\";\n", dict);
+    std::print("constexpr const uint8_t index[] = {{\n");
     for(auto b : bytes) {
-        fmt::print("0x{:02x},", b);
+        std::print("0x{:02x},", b);
     }
-    fmt::print("0}};\n}}\n");
+    std::print("0}};\n}}\n");
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,11 +1,8 @@
 {
-    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
     "name": "pacman",
     "version": "0.1",
     "dependencies": [
-        "tbb",
-        "range-v3",
-        "fmt",
         "catch2",
         "pugixml"
     ]


### PR DESCRIPTION
This PR overall simplifies the project structure using C++23.

Since we now have `<format>` and `<ranges>` there's very little reason to have ranges-v3 and fmt third-party dependencies.

Secondly, I couldn't get `<execution>` with TBB to work on GCC for whatever reason, and we may as well get rid of it. The names build fast enough without `par_seq` on release, so this is just adding another complication to the build process to shave off a second or two off a build process that you perform in a blue moon.

Note that generation doesn't work because of #11.

I've changed the `.cpp` files as little as possible, just replacing `fmt` with `std` and other menial changes. That way, it should be easy to verify that nothing is broken by this PR.